### PR TITLE
Update kill-stupid-top-bar.sh for 13.10+

### DIFF
--- a/kill-stupid-top-bar.sh
+++ b/kill-stupid-top-bar.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -x
 # http://lifehacker.com/5887462/how-to-disable-ubuntus-annoying-global-menu-bar
-sudo aptitude purge appmenu-gtk appmenu-gtk3 appmenu-qt
+sudo aptitude purge appmenu-gtk appmenu-gtk3 appmenu-qt indicator-appmenu


### PR DESCRIPTION
Added 'indicator-appmenu' to the list of uninstalled packages so that the global menu bar gets removed in Ubuntu 13.10 and 14.04.
